### PR TITLE
fixed broken maps, cleaned up js

### DIFF
--- a/moremaps.pjs
+++ b/moremaps.pjs
@@ -1,64 +1,77 @@
 // {"author":"GosportXplorer","description":"more maps"}
+// Reworked by dziban303
 
 removeTileLayerAll();
 removeOverlayLayerAll();
 
-addTileLayer("Voyager",L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', { attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>', subdomains: 'abcd', maxZoom: 20 }));
+addTileLayer("Voyager",L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', { 
+	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>', 
+	subdomains: 'abcd',
+	maxZoom: 20 
+}));
 
-addTileLayer("StamenWatercolour", L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.{ext}', {
+addTileLayer("Stamen Watercolor", L.tileLayer('https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/watercolor/{z}/{x}/{y}.{ext}', {
 	attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 	subdomains: 'abcd',
 	minZoom: 1,
 	maxZoom: 16,
 	ext: 'jpg'
 }));
-addTileLayer("StamenTonerLite",  L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}{r}.{ext}', {
-	attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+
+addTileLayer("Stamen Toner Lite",  L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.{ext}?api_key={stadiakey}', {
+	attribution: '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors', 
 	subdomains: 'abcd',
 	minZoom: 0,
 	maxZoom: 20,
-	ext: 'png'
+	ext: 'png',
+	stadiakey: '<your stadia key>'   
 }));
-addTileLayer("DarkMatter", L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+
+addTileLayer("Dark Matter", L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
 	subdomains: 'abcd',
-	maxZoom: 20 }));
+	maxZoom: 20
+}));
+
 addTileLayer("Satellite", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
 	attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
 }));
 
-addTileLayer("MtbMap", L.tileLayer('http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png', {
+addTileLayer("MTB Map", L.tileLayer('http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png', {
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &amp; USGS'
 }));
-addTileLayer("OSM_HOT",  L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+
+addTileLayer("OSM HOT",  L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
 }));
 
-addTileLayer("Thunderforest_TransportDark", L.tileLayer('https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}.png?apikey={apikey}', {
+addTileLayer("Thunderforest Transport Dark", L.tileLayer('https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}.png?apikey={apikey}', {
 	attribution: '&copy; <a href="http://www.thunderforest.com/">Thunderforest</a>, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-	apikey: '<your apikey>',
+	apikey: '<your Thunderforst apikey>',
 	maxZoom: 22
 }));
-addTileLayer("Jawg_Matrix", L.tileLayer('https://{s}.tile.jawg.io/jawg-matrix/{z}/{x}/{y}{r}.png?access-token={accessToken}', {
+
+addTileLayer("Jawg Matrix", L.tileLayer('https://{s}.tile.jawg.io/jawg-matrix/{z}/{x}/{y}{r}.png?access-token={accessToken}', {
 	attribution: '<a href="http://jawg.io" title="Tiles Courtesy of Jawg Maps" target="_blank">&copy; <b>Jawg</b>Maps</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 	minZoom: 0,
 	maxZoom: 22,
 	subdomains: 'abcd',
-	accessToken: '<your accessToken>'
+	accessToken: '<your Jawg accessToken>'
 }));
 
-addTileLayer("googleStreets", L.tileLayer('http://{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}',{
+addTileLayer("Google Streets", L.tileLayer('http://{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}',{
     maxZoom: 20,
     subdomains:['mt0','mt1','mt2','mt3']
 }));
 
 
-addTileLayer("googleSattelite", L.tileLayer('http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',{
+addTileLayer("Google Satellite", L.tileLayer('http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',{
     maxZoom: 20,
     subdomains:['mt0','mt1','mt2','mt3']
 }));
-addTileLayer("googleTerrain", L.tileLayer('http://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
+
+addTileLayer("Google Terrain", L.tileLayer('http://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
     maxZoom: 20,
     subdomains:['mt0','mt1','mt2','mt3']
 }));
@@ -69,34 +82,43 @@ addTileLayer("Mapbox", L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/
 	id: 'mapbox/streets-v11',
 	tileSize: 512,
 	zoomOffset: -1,
-	accessToken: 'your.mapbox.access.token'}));
+	accessToken: 'your mapbox access token'
+}));
 
 addTileLayer("OpenTopoMap", L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', { 
-	attribution: 'Map data © OpenStreetMap contributors, SRTM | Map style © OpenTopoMap (CC-BY-SA)'}));
+	attribution: 'Map data © OpenStreetMap contributors, SRTM | Map style © OpenTopoMap (CC-BY-SA)'
+}));
 
 addTileLayer("CartoDB", L.tileLayer('https://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}.png', { 
 	attribution: '© <a href="https://carto.com/">CARTO</a>',
 	maxZoom: 18,
-	variant: 'rastertiles/voyager_nolabels_under'}));
+	variant: 'rastertiles/voyager_nolabels_under'
+}));
 
-addTileLayer("World_Street_Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri'}));
+addTileLayer("World Street Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri'
+}));
 
-addTileLayer("World_Imagery", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri'}));
+addTileLayer("World Imagery", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri'
+}));
 
-addTileLayer("World_Terrain_Base", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri | Source: USGS, Esri, TANA, DeLorme, and NPS'}));
+addTileLayer("World Terrain Base", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri | Source: USGS, Esri, TANA, DeLorme, and NPS'
+}));
 	
-addTileLayer("World_Topo_Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri'}));
+addTileLayer("World Topo Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri'
+}));
 	
-addTileLayer("World_Shaded_Relief", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri | Sources: USGS, Esri'}));
+addTileLayer("World Shaded Relief", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri | Sources: USGS, Esri'
+}));
 	
-addTileLayer("World_Hillshade", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Hillshade/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri | Sources: USGS, Esri'}));
+addTileLayer("NatGeo World Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; NatGeo, Esri | Sources: USGS, Esri'
+}));
 
-addTileLayer("World_Physical_Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer/tile/{z}/{y}/{x}', { 
-	attribution: 'Tiles &copy; Esri | Sources: US National Park Service, Esri, HERE, Garmin, INCREMENT P, METI/NASA Japan, EPA, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'}));
-
+addTileLayer("World Physical Map", L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer/tile/{z}/{y}/{x}', { 
+	attribution: 'Tiles &copy; Esri | Sources: US National Park Service, Esri, HERE, Garmin, INCREMENT P, METI/NASA Japan, EPA, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
+}));


### PR DESCRIPTION
I don't know if anyone besides me uses `moremaps.pjs` but, in case they do, I've cleaned this up by fixing URLs for some maps which have changed locations (Stamen Watercolor and Stamen Toner) and replaced the no longer available ESRI World Hillshade with the National Geographic World map.

Note the Stamen Toner Lite map now requires an API key from Stadia Maps.

Also fixed the map name text and cleaned up the js to soothe my OCD.